### PR TITLE
Add FiLM emotion conditioning and fix training bugs

### DIFF
--- a/src/f5_tts/model/__init__.py
+++ b/src/f5_tts/model/__init__.py
@@ -9,4 +9,4 @@ from f5_tts.model.backbones.mmdit import MMDiT
 from f5_tts.model.trainer import Trainer
 
 
-__all__ = ["CFM", "UNetT", "DiT", "MMDiT", "Trainer"]
+__all__ = ["CFM", "CFMConditioned", "UNetT", "DiT", "DiTConditioned", "MMDiT", "Trainer"]

--- a/src/f5_tts/model/backbones/dit_emotion.py
+++ b/src/f5_tts/model/backbones/dit_emotion.py
@@ -173,7 +173,7 @@ class InputEmbedding(nn.Module):
         if drop_audio_cond:  # cfg for cond audio
             cond = torch.zeros_like(cond)
 
-        if self.emotion_condition_type in ['no_emotion_condition', 'text_early_fusion', 'cross_attention', 'film']:
+        if self.emotion_condition_type in ['no_emotion_condition', 'text_early_fusion', 'film']:
             x = self.proj(torch.cat((x, cond, text_embed), dim=-1))
         elif self.emotion_condition_type == 'text_mirror':
             x = self.proj_emotion(torch.cat((x, cond, text_embed, emotion_embed), dim=-1))
@@ -214,11 +214,12 @@ class DiTConditioned(nn.Module):
             emotion_dim = mel_dim
         self.text_embed = TextEmbedding(self.emotion_conditioning['emotion_condition_type'], text_num_embeds, text_dim, conv_layers=conv_layers, emotion_num_embeds=emotion_num_embeds, emotion_dim=emotion_dim)
         self.emotion_embed = EmotionEmbedding(emotion_num_embeds, emotion_dim, conv_layers=conv_layers)
-        self.input_embed = InputEmbedding(mel_dim, text_dim, emotion_dim, dim, emotion_condition_type=self.emotion_conditioning['emotion_condition_type'], load_emotion_weights=self.emotion_conditioning['load_emotion_weights'])
+        self.input_embed = InputEmbedding(mel_dim, text_dim, emotion_dim, dim, emotion_condition_type=self.emotion_conditioning['emotion_condition_type'], load_emotion_weights=self.emotion_conditioning.get('load_emotion_weights', False))
         
-        self.emotion_film_blocks = nn.ModuleList([
-            EmotionFiLM(dim, emotion_dim) for _ in range(depth)
-        ])
+        if self.emotion_conditioning['emotion_condition_type'] == 'film':
+            self.emotion_film_blocks = nn.ModuleList([
+                EmotionFiLM(dim, emotion_dim) for _ in range(depth)
+            ])
 
         self.rotary_embed = RotaryEmbedding(dim_head)
 

--- a/src/f5_tts/model/backbones/dit_emotion.py
+++ b/src/f5_tts/model/backbones/dit_emotion.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import torch
 from torch import nn
 import torch.nn.functional as F
-#import torchshow as ts
 
 from x_transformers.x_transformers import RotaryEmbedding
 
@@ -24,51 +23,8 @@ from f5_tts.model.modules import (
     AdaLayerNormZero_Final,
     precompute_freqs_cis,
     get_pos_embed_indices,
+    EmotionFiLM,
 )
-
-import os
-import torch
-from torch.utils.tensorboard import SummaryWriter
-
-writer = SummaryWriter(log_dir="ckpts/runs/emotion_embeddings")
-
-EMBEDDINGS_FILE = "ckpts/emotion_embeddings.pt"
-
-def get_iteration():
-    return int(os.environ.get("ITERATION_COUNT", "0"))
-
-def increment_iteration():
-    os.environ["ITERATION_COUNT"] = str(get_iteration() + 1)
-
-def get_emotion_embeddings():
-    if os.path.exists(EMBEDDINGS_FILE):
-        return torch.load(EMBEDDINGS_FILE)
-    return []
-
-def save_emotion_embeddings(embeddings):
-    torch.save(embeddings, EMBEDDINGS_FILE)
-
-def register_emotion_embedding(emotion_embed):
-    embeddings = get_emotion_embeddings()
-
-    # Clone and move to CPU
-    cloned_embedding = emotion_embed.clone().detach().cpu()
-
-    embeddings.append(cloned_embedding)
-
-    # Store up to 100 embeddings
-    # if len(embeddings) < 100:
-    #     embeddings.append(cloned_embedding)
-    # else:
-    #     embeddings.pop(0)  # Remove the oldest embedding
-    #     embeddings.append(cloned_embedding)
-
-    save_emotion_embeddings(embeddings)
-
-    if len(embeddings) == 200:
-        stacked_embeddings = torch.stack(embeddings) 
-        writer.add_embedding(stacked_embeddings, global_step=get_iteration(), tag="Emotion Embeddings")
-        print(f"Logged {len(embeddings)} emotion embeddings at iteration {get_iteration()}")
 
 # Text embedding
 class TextEmbedding(nn.Module):
@@ -134,10 +90,9 @@ class TextEmbedding(nn.Module):
 
 # V2) New emotion encoding
 class EmotionEmbedding(nn.Module):
-    def __init__(self, emotion_num_embeds, emotion_dim, conv_layers=0, conv_mult=2, visualize_emotion_embeddings=False):
+    def __init__(self, emotion_num_embeds, emotion_dim, conv_layers=0, conv_mult=2):
         super().__init__()
         self.emotion_embeder = nn.Embedding(emotion_num_embeds + 1, emotion_dim)  # use 0 as filler token
-        self.visualize_emotion_embeddings = visualize_emotion_embeddings
 
         if conv_layers > 0:
             self.extra_modeling = True
@@ -150,25 +105,15 @@ class EmotionEmbedding(nn.Module):
             self.extra_modeling = False
 
     def forward(self, emotion: int["b nt"], seq_len, drop_emotion=False):  # noqa: F722
-        emotion = emotion + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx() 
-        emotion = emotion[:, :seq_len]  # Truncate if text tokens exceed mel spec length (rare case, but included for safety)
+        emotion = emotion + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
+        emotion = emotion[:, :seq_len]  # Truncate if tokens exceed mel spec length
         batch, emotion_len = emotion.shape[0], emotion.shape[1]
-        emotion = F.pad(emotion, (0, seq_len - emotion_len), value=0) # padd to match the cond (melspec) along seq_len.
+        emotion = F.pad(emotion, (0, seq_len - emotion_len), value=0)
 
         if drop_emotion:  # cfg for emotion
             emotion = torch.zeros_like(emotion)
 
-        emotion = self.emotion_embeder(emotion)  # b n -> b n d # every token has an embedding, but the last ones will have the 0 filler embeddign from the padding
-
-        if self.visualize_emotion_embeddings:
-            increment_iteration()
-            it = get_iteration()
-            print('iteration: ', it)
-            if it > 0:
-                register_emotion_embedding(emotion[0, 0, :])
-
-            if it > 800:
-                writer.flush()
+        emotion = self.emotion_embeder(emotion)  # b n -> b n d
 
         # possible extra modeling
         if self.extra_modeling:
@@ -185,26 +130,9 @@ class EmotionEmbedding(nn.Module):
 
 
 
-# noised input audio and context mixing embedding
+# noised input audio and context mixing embedding (with emotion)
 
-# V1)
-# The old InputEmbedding that has no emotion (🧊)
-# class InputEmbedding(nn.Module):
-#     def __init__(self, mel_dim, text_dim, emotion_dim, out_dim):
-#         super().__init__()
-#         self.proj = nn.Linear(mel_dim * 2 + text_dim, out_dim)
-#         self.conv_pos_embed = ConvPositionEmbedding(dim=out_dim)
-
-#     def forward(self, x: float["b n d"], cond: float["b n d"], text_embed: float["b n d"], drop_audio_cond=False):  # noqa: F722
-#         if drop_audio_cond:  # cfg for cond audio
-#             cond = torch.zeros_like(cond)
-#         x = self.proj(torch.cat((x, cond, text_embed), dim=-1))
-#         x = self.conv_pos_embed(x) + x
-#         return x
-
-
-# V2) With emotion
-class InputEmbedding(nn.Module): # The InputEmeddign with emotion
+class InputEmbedding(nn.Module):
     def __init__(self, mel_dim, text_dim, emotion_dim, out_dim, emotion_condition_type, load_emotion_weights=True):
         super().__init__()
         self.proj = nn.Linear(mel_dim * 2 + text_dim, out_dim) # old (no emotion)
@@ -245,7 +173,7 @@ class InputEmbedding(nn.Module): # The InputEmeddign with emotion
         if drop_audio_cond:  # cfg for cond audio
             cond = torch.zeros_like(cond)
 
-        if self.emotion_condition_type in ['no_emotion_condition', 'text_early_fusion', 'cross_attention']:
+        if self.emotion_condition_type in ['no_emotion_condition', 'text_early_fusion', 'cross_attention', 'film']:
             x = self.proj(torch.cat((x, cond, text_embed), dim=-1))
         elif self.emotion_condition_type == 'text_mirror':
             x = self.proj_emotion(torch.cat((x, cond, text_embed, emotion_embed), dim=-1))
@@ -255,28 +183,6 @@ class InputEmbedding(nn.Module): # The InputEmeddign with emotion
         x = self.conv_pos_embed(x) + x
 
         return x
-
-class EmotionCrossAttention(nn.Module):
-    def __init__(self, dim):
-        super().__init__()
-        self.attn = nn.MultiheadAttention(dim, num_heads=8, batch_first=True)
-        self.gate = nn.Sequential(
-            nn.Linear(dim, 1),
-            nn.Sigmoid()
-        )
-
-    def forward(self, hidden_states, emotion_embedding):
-        # Q = model hidden states -> the main source of information
-        # K and V = emotion embeddings -> the external information being injected
-        attn_output, _ = self.attn(hidden_states, emotion_embedding, emotion_embedding)
-        # V1) residual connection
-        return hidden_states + attn_output
-        # V2)
-        #return attn_output # 
-        # v3)
-        #alpha = 0.2
-        #alpha = self.gate(hidden_states)
-        #return (1 - alpha) * hidden_states + alpha * attn_output
 
 # Transformer backbone using DiT blocks
 class DiTConditioned(nn.Module):
@@ -310,9 +216,8 @@ class DiTConditioned(nn.Module):
         self.emotion_embed = EmotionEmbedding(emotion_num_embeds, emotion_dim, conv_layers=conv_layers)
         self.input_embed = InputEmbedding(mel_dim, text_dim, emotion_dim, dim, emotion_condition_type=self.emotion_conditioning['emotion_condition_type'], load_emotion_weights=self.emotion_conditioning['load_emotion_weights'])
         
-        # V1) and V2) -> one single corss attention isntance
-        self.emotion_cross_attn_blocks = nn.ModuleList([
-            EmotionCrossAttention(dim) for _ in range(depth)
+        self.emotion_film_blocks = nn.ModuleList([
+            EmotionFiLM(dim, emotion_dim) for _ in range(depth)
         ])
 
         self.rotary_embed = RotaryEmbedding(dim_head)
@@ -350,34 +255,26 @@ class DiTConditioned(nn.Module):
         text_embed = self.text_embed(text, emotion, seq_len, drop_text=drop_text, drop_emotion=drop_emotion_cond)
         
         if self.emotion_conditioning['emotion_condition_type'] in ['no_emotion_condition', 'text_early_fusion']:
-            x = self.input_embed(x, cond, text_embed, drop_audio_cond=drop_audio_cond) # no emotion_embed transmitted
-        elif self.emotion_conditioning['emotion_condition_type'] == 'cross_attention':
-            emotion_embed = self.emotion_embed(emotion, seq_len, drop_emotion=drop_emotion_cond) # still compute emotion embedding
             x = self.input_embed(x, cond, text_embed, drop_audio_cond=drop_audio_cond)
-
+            emotion_embed = None
+        elif self.emotion_conditioning['emotion_condition_type'] == 'film':
+            emotion_embed = self.emotion_embed(emotion, seq_len, drop_emotion=drop_emotion_cond)
+            x = self.input_embed(x, cond, text_embed, drop_audio_cond=drop_audio_cond)
         elif self.emotion_conditioning['emotion_condition_type'] == 'text_mirror':
             emotion_embed = self.emotion_embed(emotion, seq_len, drop_emotion=drop_emotion_cond)
             x = self.input_embed(x, cond, text_embed, emotion_embed, drop_audio_cond=drop_audio_cond)
         else:
             raise NotImplementedError(f'emotion_condition_type {self.emotion_conditioning["emotion_condition_type"]} is not implemented yet')
 
-
         rope = self.rotary_embed.forward_from_seq_len(seq_len)
 
         if self.long_skip_connection is not None:
             residual = x
 
-        for i, block in enumerate(self.transformer_blocks): 
-            if self.emotion_conditioning['emotion_condition_type'] == 'cross_attention':
-                # V1) apply coss attention here
-                #x = self.emotion_cross_attn(x, emotion_embed)
-                # V2) only apply cross attention in the 1st iteration
-                # if i==0:
-                #     x = self.emotion_cross_attn(x, emotion_embed)
-                # V3) One cross attention for each transition
-                x = self.emotion_cross_attn_blocks[i](x, emotion_embed)
-                 
+        for i, block in enumerate(self.transformer_blocks):
             x = block(x, t, mask=mask, rope=rope)
+            if emotion_embed is not None and self.emotion_conditioning['emotion_condition_type'] == 'film':
+                x = self.emotion_film_blocks[i](x, emotion_embed)
 
         if self.long_skip_connection is not None:
             x = self.long_skip_connection(torch.cat((x, residual), dim=-1))

--- a/src/f5_tts/model/cfm.py
+++ b/src/f5_tts/model/cfm.py
@@ -137,7 +137,7 @@ class CFM(nn.Module):
         duration = duration.clamp(max=max_duration)
         max_duration = duration.amax()
 
-        # duplicate test corner for inner time step oberservation
+        # duplicate test corner for inner time step observation
         if duplicate_test:
             test_cond = F.pad(cond, (0, 0, cond_seq_len, max_duration - 2 * cond_seq_len), value=0.0)
 
@@ -187,7 +187,7 @@ class CFM(nn.Module):
 
         t_start = 0
 
-        # duplicate test corner for inner time step oberservation
+        # duplicate test corner for inner time step observation
         if duplicate_test:
             t_start = t_inter
             y0 = (1 - t_start) * y0 + t_start * test_cond
@@ -200,8 +200,7 @@ class CFM(nn.Module):
 
         trajectory = odeint(fn, y0, t, **self.odeint_kwargs) # contains all the flow steps so far
 
-        sampled = trajectory[-1] # save the last foucntion evaluation (the last flow step)
-        #print('sampled.shape: ', sampled.shape) 
+        sampled = trajectory[-1] # save the last function evaluation (the last flow step)
         out = sampled
 
         out = torch.where(cond_mask, cond, out)
@@ -238,7 +237,7 @@ class CFM(nn.Module):
             assert text.shape[0] == batch
 
         # lens and mask
-        if not exists(lens): # lens are usually provided from then trainig script
+        if not exists(lens): # lens are usually provided from the training script
             lens = torch.full((batch,), seq_len, device=device)
 
         mask = lens_to_mask(lens, length=seq_len)  # useless here, as collate_fn will pad to max length in batch

--- a/src/f5_tts/model/cfm_emotion.py
+++ b/src/f5_tts/model/cfm_emotion.py
@@ -357,8 +357,6 @@ class CFMConditioned(nn.Module):
             drop_text = False
             drop_emotion_cond = False
 
-        drop_emotion_cond = False
-
         # if want rigorously mask out padding, record in collate_fn in dataset.py, and pass in here
         # adding mask will use more memory, thus also need to adjust batchsampler with scaled down threshold for long sequences
         pred = self.transformer(

--- a/src/f5_tts/model/cfm_emotion.py
+++ b/src/f5_tts/model/cfm_emotion.py
@@ -87,10 +87,10 @@ class CFMConditioned(nn.Module):
     def device(self):
         return next(self.parameters()).device
 
-    def tokenize_emotion(self, emotion, text_shape, first_phrase_length,initial_text_dims, device):
+    def tokenize_emotion(self, emotion, text_shape, first_phrase_length, initial_text_dims, device):
         emotion = torch.tensor([[self.emotion_dict.get(emotion, 0) for emotion in batch] for batch in emotion], device=device)
         if 0 in emotion:
-            raise('Unknown emotion found in the emotion conditioning input.')
+            raise ValueError('Unknown emotion found in the emotion conditioning input.')
         emotion_tokens = torch.full((emotion.shape[0], text_shape), -1, device=device)
         for i in range(len(first_phrase_length)):
             emotion_tokens[i, first_phrase_length[i]:initial_text_dims[i]] = emotion[i, 1].item()
@@ -203,8 +203,6 @@ class CFMConditioned(nn.Module):
                 )
                 return pred + (pred - null_pred) * cfg_strength + (pred - half_pred) * cfg_strength2
             else:
-                print('cfg_strength2 is None. Classical CFM applied')
-                
                 return pred + (pred - null_pred) * cfg_strength
 
         # noise input
@@ -264,27 +262,16 @@ class CFMConditioned(nn.Module):
         contrastive_loss = isinstance(emotion, tuple)
         if contrastive_loss:
             emotion, emotion2 = emotion
-            #print(emotion, emotion2)
 
         mode = None
         if change_emotion_forward:
-            #mode = 'binary_interpolation'
             mode = 'triple_interpolation'
-            if mode == 'binary_interpolation':
-                change_target = random() < 0.5
-                if change_target:
-                    mel_target, mel_source = inp
-                    inp = mel_source
-                else:
-                    mel_target, mel_source = inp
-                    inp = mel_target
-            elif mode == 'triple_interpolation':
-                mel1, mel2 = inp
-                #mel_source = 
-                mel_target = mel1
-                inp = mel_target
+            mel1, mel2 = inp
+            mel_target = mel1
+            mel_source = mel2
+            inp = mel_target
 
-    
+
         # handle raw wave
         if inp.ndim == 2:
             inp = self.mel_spec(inp)
@@ -307,12 +294,9 @@ class CFMConditioned(nn.Module):
         emotion = self.tokenize_emotion(emotion, text.shape[1], first_phrase_length, initial_text_dims, device)
         if contrastive_loss:
             emotion2 = self.tokenize_emotion(emotion2, text.shape[1], first_phrase_length, initial_text_dims, device)
-        # print('emotion after torkenizing in CFM (before transfoermer): ')
-        # print('emotion.shape: ', emotion.shape)
-        # print('emotion: ', emotion)
 
         # lens and mask
-        if not exists(lens): # lens are usually provided from then trainig script
+        if not exists(lens): # lens are usually provided from the training script
             lens = torch.full((batch,), seq_len, device=device)
 
         mask = lens_to_mask(lens, length=seq_len)  # useless here, as collate_fn will pad to max length in batch
@@ -356,10 +340,7 @@ class CFMConditioned(nn.Module):
             φ = (1 - t) * x0 + t * x1
             
         if change_emotion_forward:
-            if mode == 'binary_interpolation':
-                flow = mel_target - x0
-            elif mode == 'triple_interpolation':
-                flow = mel_target - mel_source
+            flow = mel_target - mel_source
         else:
             flow = x1 - x0
 

--- a/src/f5_tts/model/dataset.py
+++ b/src/f5_tts/model/dataset.py
@@ -194,12 +194,9 @@ class CustomDatasetConditioned(Dataset):
                 raise ValueError('Dataset descriptor has to be either "ESD or "RAVDESS".')
 
         self.data = self._emotion_filtering(data) # only select allowed emotions
-        # create a dict where to keep phrase_idx -> speaker_id -> emotion -> self.data idx (so that I can easily find the index in self.data of a specific phrase of a specific sepaekr and a specific emotion)
+        # phrase_idx -> speaker_id -> emotion -> self.data idx for fast lookup
         self.data_maping = self.index_data(self.data)
-        with open('tmp_dict.json', 'w') as file:
-            json.dump(self.data_maping, file)
-        #self.durations = durations
-        
+
 
         self.target_sample_rate = mel_spec_kwargs['target_sample_rate']
         self.hop_length = mel_spec_kwargs['hop_length']
@@ -208,10 +205,8 @@ class CustomDatasetConditioned(Dataset):
         self.mel_spec_type = mel_spec_kwargs['mel_spec_type']
         self.preprocessed_mel = preprocessed_mel
         self.n_mel_channels = mel_spec_kwargs['n_mel_channels']
-        #self.change_emotion_probability = change_emotion_probability
-        #self.emotions = {"Angry", "Neutral", "Sad", "Surprise", "Happy"}
-        
-        self.phrase_idxs = {phrase_idx for phrase_idx in self.data_maping} # a set wit all phrase indexes
+
+        self.phrase_idxs = set(self.data_maping) # set of all phrase indexes
 
         if not self.preprocessed_mel: # if so melspec is computed on the fly in __getitem__()
             self.mel_spectrogram = default(
@@ -232,7 +227,7 @@ class CustomDatasetConditioned(Dataset):
 
     def index_data(self, data):
         '''
-        Trasnforms the dir such that any data sampel index can be foudn in linear time if it si searched by phrase_idx, speaker_id and emotion
+        Builds a nested dict for O(1) lookup by phrase_idx, speaker_id, and emotion.
         '''
         nested_dict = {}
 
@@ -258,31 +253,25 @@ class CustomDatasetConditioned(Dataset):
         '''
         second_phrase_idx can be imposed or it can be randomly selected, if the argument is None
         '''
-        #### mix with the second piece of utterance, if needed
         if change_emotion:
-            # choose a second utterance
-            #emotion_candidates = self.emotions - {emotion}
-            if second_phrase_idx is None: # if th e2nd phrase index is not specified
-                if self.emotion_conditioning_kwargs['same_sentence']: 
-                    second_phrase_idx = row['phrase_idx'] 
+            if second_phrase_idx is None:
+                if self.emotion_conditioning_kwargs['same_sentence']:
+                    second_phrase_idx = row['phrase_idx']
                 else:
                     second_phrase_idx = random.choice(list(self.phrase_idxs))
-            
-            #second_emotion = random.choice(list(emotion_candidates))
+
             try:
-                second_emotion = random.choice(list({emotion for emotion in self.data_maping[second_phrase_idx][row["speaker_id"]]} - {emotion})) # a list of all available emotions
+                available_emotions = set(self.data_maping[second_phrase_idx][row["speaker_id"]]) - {emotion}
+                second_emotion = random.choice(list(available_emotions))
                 second_row_index = self.data_maping[second_phrase_idx][row["speaker_id"]][second_emotion]
                 second_row = self.data[second_row_index[0]]
-            except:
-                print('!!!! Conditions not met 1. The 1st phrase will be replicated')
+            except (KeyError, IndexError):
                 second_row = row
         else:
-            attempts = 0
             max_num_attempts = 10
-            while attempts < max_num_attempts: # choose a phrase until it has that emotion
-                attempts += 1
-                if second_phrase_idx is None: # if th e2nd phrase index is not specified
-                    if self.emotion_conditioning_kwargs['same_sentence']:  
+            for _ in range(max_num_attempts):
+                if second_phrase_idx is None:
+                    if self.emotion_conditioning_kwargs['same_sentence']:
                         second_phrase_idx = row['phrase_idx']
                     else:
                         second_phrase_idx = random.choice(list(self.phrase_idxs))
@@ -291,9 +280,8 @@ class CustomDatasetConditioned(Dataset):
                     if emotion in self.data_maping[second_phrase_idx][row["speaker_id"]]:
                         second_row_index = self.data_maping[second_phrase_idx][row["speaker_id"]][emotion]
                         second_row = self.data[second_row_index[0]]
-                        break # break only if it was found
-            else: # executed if the phrase was not found (break)
-                print('!!!! Conditions not met 2. The 1st phrase will be replicated')
+                        break
+            else:
                 second_row = row
 
         # load the second piece of utterance
@@ -328,7 +316,7 @@ class CustomDatasetConditioned(Dataset):
         return mel_specs_concat, texts_concat, emotions, first_phrase_length, second_phrase_idx
 
     def __getitem__(self, index):
-        while True: # loop in case of 'contrastive_loss' tha tdoesn't find  a propper configuration
+        while True: # loop in case contrastive_loss doesn't find a proper configuration
             row = self.data[index]
 
             audio_path = row["audio_path"]
@@ -378,7 +366,6 @@ class CustomDatasetConditioned(Dataset):
                     ]
                     return sample
             else:
-                # else: only one utterance which can have the same emotion or not
                 change_emotion = random.uniform(0, 1) < self.emotion_conditioning_kwargs['change_emotion_probability']
                 mel_specs_concat, texts_concat, emotions, first_phrase_length, _ = self._sample_2nd_sentence(change_emotion, row, emotion, index, first_mel_spec)
                 return [dict(
@@ -387,12 +374,6 @@ class CustomDatasetConditioned(Dataset):
                     emotion=emotions,
                     first_phrase_length=first_phrase_length,
                 )]
-                # return dict(
-                #     mel_spec=mel_specs_concat,
-                #     text=texts_concat,
-                #     emotion=emotions,
-                #     first_phrase_length=first_phrase_length,
-                # )
 
 # Dynamic Batch Sampler
 
@@ -408,7 +389,6 @@ class DynamicBatchSampler(Sampler[list[int]]):
     def __init__(
         self, sampler: Sampler[int], frames_threshold: int, max_samples=0, random_seed=None, drop_last: bool = False
     ):
-        print('frames_threshold: ', frames_threshold)
         self.sampler = sampler
         self.frames_threshold = frames_threshold
         self.max_samples = max_samples
@@ -481,13 +461,11 @@ def load_dataset(
     print("Loading dataset ...")
 
     if dataset_type == "CustomDataset":
-        #rel_data_path = str(files("f5_tts").joinpath(f"../../data/{dataset_name}_{tokenizer}"))
-        #rel_data_path = str(files("f5_tts").joinpath(f"data/{dataset_name}_{tokenizer}"))
         rel_data_path = f"data/{dataset_name}_{tokenizer}"
         if audio_type == "raw":
             try:
                 train_dataset = load_from_disk(f"{rel_data_path}/raw")
-            except:  # noqa: E722
+            except Exception:
                 train_dataset = Dataset_.from_file(f"{rel_data_path}/raw.arrow")
             preprocessed_mel = False
         elif audio_type == "mel":

--- a/src/f5_tts/model/metrics.py
+++ b/src/f5_tts/model/metrics.py
@@ -1,5 +1,4 @@
 import numpy as np
-from nnmnkwii.metrics import melcd
 from fastdtw import fastdtw
 from pymcd.mcd import Calculate_MCD
 from scipy.spatial.distance import euclidean
@@ -12,77 +11,6 @@ import itertools
 import re
 from num2words import num2words
 
-
-__MODEL_HASH = 'f0fe81560cb8b68660e564f55dd99207059c092e'
-
-
-def load_model(model_path, language, precision):
-
-    ### checking the model is present
-    model_bin_path = os.path.join(model_path, 'snapshots', __MODEL_HASH, 'model.bin')
-    model_bin_dir_path = os.path.dirname(model_bin_path)
-    if not os.path.isfile(model_bin_path):
-        raise Exception(f"[ERROR] Model file {model_bin_path} does not exist ! Please make sure the installation is correct.")   
-    ### end check
-
-    if language == 'auto':  # not used now but kept for future updates
-        language = None
-    
-    print(f"[INFO] Loading Faster-Whisper from {model_path} ...")
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
-    
-    model = WhisperModel(model_bin_dir_path, device=device, compute_type=precision)
-    print(f"[INFO] Faster-Whisper loaded!")
-    
-    return model
-
-
-def execute_asr_faster(input_wav_filepath, model, language, word_timestamps=False):
-    try:
-        segments, info = model.transcribe(
-            audio=input_wav_filepath,
-            beam_size=5,
-            vad_filter=True,
-            vad_parameters=dict(min_silence_duration_ms=700),
-            language=language,
-            word_timestamps=word_timestamps
-        )
-        text = ''
-
-        words = []
-        if word_timestamps:
-            for segment in segments:
-                for word_info in segment.words:
-                    words.append([word_info.word, word_info.start, word_info.end])
-        words = [
-            [word.strip().strip('-').strip('.').strip(',').strip(';').strip('!').strip('?').strip('`').strip('"').strip("'").strip(":"), float(start), float(end)]
-            for word, start, end in words
-        ]
-
-        if text == '':
-            for segment in segments:
-                text += segment.text
-    except:
-        return traceback.format_exc()
-    
-    if word_timestamps:
-        return words
-    else:
-        return text
-
-
-def get_mcd(mel1, mel2):
-    # mel1 = mel1.numpy()  # Shape: (X, 100)
-    # mel2 = mel2.numpy()  # Shape: (X, 100)
-
-    mcd_value = melcd(mel1, mel2)
-    return mcd_value
-
-def align_with_dtw(X, Y):
-    _, path = fastdtw(X, Y, dist=lambda x, y: np.linalg.norm(x - y))
-    aligned_X = np.array([X[i] for i, _ in path])
-    aligned_Y = np.array([Y[j] for _, j in path])
-    return aligned_X, aligned_Y
 
 class Calculate_MCD_from_ndarray(Calculate_MCD):
     def __init__(self, *args, **kwargs):
@@ -131,12 +59,6 @@ class Calculate_MCD_from_ndarray(Calculate_MCD):
 
         return mean_mcd
 
-def get_mcd_dtw(audio1, audio2, audios_sample_rate):
-    mcd_toolbox = Calculate_MCD_from_ndarray(MCD_mode="dtw")
-    mcd_value = mcd_toolbox.calculate_mcd(audio1, audio2, audios_sample_rate)
-
-    return mcd_value
-
 class WhisperModelAdapter():
     def __init__(self, faster_whisper_path, text_language, precision, device):
         self.__MODEL_HASH = 'f0fe81560cb8b68660e564f55dd99207059c092e'
@@ -181,7 +103,7 @@ class WhisperModelAdapter():
             if text == '':
                 for segment in segments:
                     text += segment.text
-        except:
+        except Exception:
             return traceback.format_exc()
         
         return text

--- a/src/f5_tts/model/modules.py
+++ b/src/f5_tts/model/modules.py
@@ -180,7 +180,7 @@ class ConvPositionEmbedding(nn.Module):
             mask = mask[..., None]
             x = x.masked_fill(~mask, 0.0)
 
-        x = x.permute(0, 2, 1) # conv kernel slides along the feature dimesnion. because the last dimesnion is the feature dimension, it gets replaced with the sequence dimension. 
+        x = x.permute(0, 2, 1) # conv kernel slides along the feature dimension
         x = self.conv1d(x)
         out = x.permute(0, 2, 1)
 
@@ -533,6 +533,28 @@ class JointAttnProcessor:
             # c = c.masked_fill(~mask, 0.)  # no mask for c (text)
 
         return x, c
+
+
+# FiLM modulation for emotion conditioning (style/prosody control)
+
+
+class EmotionFiLM(nn.Module):
+    def __init__(self, dim, emotion_embed_dim):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.proj = nn.Sequential(
+            nn.Linear(emotion_embed_dim, dim),
+            nn.SiLU(),
+            nn.Linear(dim, dim * 2),
+        )
+        nn.init.zeros_(self.proj[-1].weight)
+        nn.init.zeros_(self.proj[-1].bias)
+
+    def forward(self, x, emotion_embed):
+        emotion_global = emotion_embed.mean(dim=1)
+        params = self.proj(emotion_global)
+        scale, shift = params.chunk(2, dim=-1)
+        return self.norm(x) * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
 
 
 # DiT Block

--- a/src/f5_tts/model/trainer.py
+++ b/src/f5_tts/model/trainer.py
@@ -93,7 +93,6 @@ class Trainer:
             from torch.utils.tensorboard import SummaryWriter
 
             self.writer = SummaryWriter(log_dir=f"runs/{wandb_run_name}")
-            print("sumary wrighter at: ", f"runs/{wandb_run_name}")
 
         self.model = model
 
@@ -143,14 +142,11 @@ class Trainer:
             if not os.path.exists(self.checkpoint_path):
                 os.makedirs(self.checkpoint_path)
             if last:
-                print(self.checkpoint_path)
-                print(f"Saved model as: ", f"{self.checkpoint_path}/model_last.pt")
                 self.accelerator.save(checkpoint, f"{self.checkpoint_path}/model_last.pt")
                 print(f"Saved last checkpoint at step {step}")
             else:
-                print(self.checkpoint_path)
-                print(f"{self.checkpoint_path}/model_{step}.pt")
                 self.accelerator.save(checkpoint, f"{self.checkpoint_path}/model_{step}.pt")
+                print(f"Saved checkpoint at step {step}")
 
     def load_checkpoint(self):
         if (
@@ -164,13 +160,10 @@ class Trainer:
         if "model_last.pt" in os.listdir(self.checkpoint_path):
             latest_checkpoint = "model_last.pt"
         else:
-            print('self.checkpoint_path: ', self.checkpoint_path)
-            print(os.listdir(self.checkpoint_path))
             latest_checkpoint = sorted(
                 [f for f in os.listdir(self.checkpoint_path) if f.endswith(".pt")],
                 key=lambda x: int("".join(filter(str.isdigit, x))),
             )[-1]
-        # checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", map_location=self.accelerator.device)  # rather use accelerator.load_state ಥ_ಥ
         checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", weights_only=True, map_location="cpu")
 
         # patch for backward compatibility, 305e3ea
@@ -209,7 +202,6 @@ class Trainer:
         torchaudio.save(
             ref_wav_path, ref_audio.cpu(), target_sample_rate
         )
-        print('Saved wav sample at: ', ref_wav_path)
         with torch.inference_mode():
             generated, _ = self.accelerator.unwrap_model(self.model).sample(
                 cond=mel_spec[0][:ref_audio_len].unsqueeze(0),
@@ -226,9 +218,8 @@ class Trainer:
         torchaudio.save(
             gen_wav_path, gen_audio.cpu(), target_sample_rate
         )
-        print('Saved wav sample at: ', gen_wav_path)
 
-    def _return_dataloader(self, dataset_instance, num_workers, collate_fn, generator):
+    def _return_dataloader(self, dataset_instance, num_workers, collate_fn, generator, resumable_with_seed=None):
         if self.batch_size_type == "sample":
             dataloader_instance = DataLoader(
                 dataset_instance,
@@ -242,13 +233,10 @@ class Trainer:
             )
         elif self.batch_size_type == "frame":
             self.accelerator.even_batches = False
-            print('len(train_dataset): ', len(train_dataset))
-            sampler = SequentialSampler(train_dataset)
-            print('len(sampler): ', len(sampler))
+            sampler = SequentialSampler(dataset_instance)
             batch_sampler = DynamicBatchSampler(
                 sampler, self.batch_size, max_samples=self.max_samples, random_seed=resumable_with_seed, drop_last=False
             )
-            print('len(batch_sampler): ', len(batch_sampler))
             dataloader_instance = DataLoader(
                 dataset_instance,
                 collate_fn=collate_fn,
@@ -257,7 +245,6 @@ class Trainer:
                 persistent_workers=True,
                 batch_sampler=batch_sampler,
             )
-            print('len(dataloader_instance): ', len(dataloader_instance))
         else:
             raise ValueError(f"batch_size_type must be either 'sample' or 'frame', but received {self.batch_size_type}")
         return dataloader_instance
@@ -283,7 +270,6 @@ class Trainer:
             vocoder = load_vocoder(vocoder_name=self.vocoder_name)
             target_sample_rate = self.accelerator.unwrap_model(self.model).mel_spec.target_sample_rate
             log_samples_path = f"{self.checkpoint_path}/samples"
-            print('log_sample_path: ', log_samples_path)
             os.makedirs(log_samples_path, exist_ok=True)
 
         if exists(resumable_with_seed):
@@ -292,16 +278,14 @@ class Trainer:
         else:
             generator = None
 
-        train_dataloader = self._return_dataloader(train_dataset, num_workers, collate_fn, generator)
-        #val_dataloader = self._return_dataloader(val_dataset, num_workers, collate_fn, generator)
+        train_dataloader = self._return_dataloader(train_dataset, num_workers, collate_fn, generator, resumable_with_seed)
 
-        #  accelerator.prepare() dispatches batches to devices;
-        #  which means the length of dataloader calculated before, should consider the number of devices
+        # accelerator.prepare() dispatches batches to devices;
+        # which means the length of dataloader calculated before, should consider the number of devices
         warmup_steps = (
             self.num_warmup_updates * self.accelerator.num_processes
         )  # consider a fixed warmup steps while using accelerate multi-gpu ddp
         # otherwise by default with split_batches=False, warmup steps change with num_processes
-        print('len(train_dataloader): ', len(train_dataloader))
         total_steps = len(train_dataloader) * self.epochs / self.grad_accumulation_steps
         decay_steps = total_steps - warmup_steps
         warmup_scheduler = LinearLR(self.optimizer, start_factor=1e-8, end_factor=1.0, total_iters=warmup_steps)
@@ -392,7 +376,6 @@ class Trainer:
                     self.save_checkpoint(global_step)
 
                 if global_step % self.last_per_steps == 0:
-                    print('call at save_checkpoint')
                     self.save_checkpoint(global_step, last=True)
 
         self.save_checkpoint(global_step, last=True)

--- a/src/f5_tts/model/trainer_emotion.py
+++ b/src/f5_tts/model/trainer_emotion.py
@@ -17,18 +17,9 @@ from tqdm import tqdm
 from f5_tts.model import CFM
 from f5_tts.model.dataset import DynamicBatchSampler, collate_fn, collate_fn_emotion
 from f5_tts.model.utils import default, exists
-from f5_tts.model.metrics import get_mcd_dtw, Calculate_MCD_from_ndarray, WhisperModelAdapter, get_error, replace_special_characters, link_words
-import matplotlib.pyplot as plt
+from f5_tts.model.metrics import Calculate_MCD_from_ndarray, WhisperModelAdapter, get_error, replace_special_characters, link_words
 from jiwer import wer
 import torch.nn.functional as F
-import psutil
-
-def get_memory_usage():
-    process = psutil.Process()
-    memory_info = process.memory_info()
-    memory_usage_mb = memory_info.rss / (1024 * 1024)
-    
-    return float(memory_usage_mb)
 
 
 class TrainerConditioned:
@@ -115,7 +106,6 @@ class TrainerConditioned:
         self.save_per_updates = save_per_updates
         self.last_per_steps = default(last_per_steps, save_per_updates * grad_accumulation_steps)
         self.checkpoint_path = default(checkpoint_path, "ckpts/test_e2-tts")
-        print('self.checkpoint_path :', self.checkpoint_path)
 
         self.batch_size = batch_size
         self.batch_size_type = batch_size_type
@@ -153,12 +143,11 @@ class TrainerConditioned:
             if not os.path.exists(self.checkpoint_path):
                 os.makedirs(self.checkpoint_path)
             if last:
-                print(f"Saved model as: ", f"{self.checkpoint_path}/model_last.pt")
                 self.accelerator.save(checkpoint, f"{self.checkpoint_path}/model_last.pt")
                 print(f"Saved last checkpoint at step {step}")
             else:
-                print(f"{self.checkpoint_path}/model_{step}.pt")
                 self.accelerator.save(checkpoint, f"{self.checkpoint_path}/model_{step}.pt")
+                print(f"Saved checkpoint at step {step}")
 
     def load_checkpoint(self):
         if (
@@ -172,13 +161,10 @@ class TrainerConditioned:
         if "model_last.pt" in os.listdir(self.checkpoint_path):
             latest_checkpoint = "model_last.pt"
         else:
-            print('self.checkpoint_path: ', self.checkpoint_path)
-            print(os.listdir(self.checkpoint_path))
             latest_checkpoint = sorted(
                 [f for f in os.listdir(self.checkpoint_path) if f.endswith(".pt")],
                 key=lambda x: int("".join(filter(str.isdigit, x))),
             )[-1]
-        # checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", map_location=self.accelerator.device)  # rather use accelerator.load_state ಥ_ಥ
         checkpoint = torch.load(f"{self.checkpoint_path}/{latest_checkpoint}", weights_only=True, map_location="cpu")
 
         # patch for backward compatibility, 305e3ea
@@ -240,7 +226,6 @@ class TrainerConditioned:
                         gen_audio = vocoder.decode(
                             generated[:, ref_audio_len:, :].permute(0, 2, 1).to(self.accelerator.device)
                         )
-                        print('emotion_inputs: ', emotion_inputs)
                 elif masking_type == '2nd_part_proportional_masked':
                     cond = mel_spec[0, :int((first_phrase_length[0] * ref_audio_len / len(text_inputs[0])))] # select only the 1st part of the cond
 
@@ -276,7 +261,6 @@ class TrainerConditioned:
                 persistent_workers=True,
                 batch_size=batch_size,
                 shuffle=True,
-                #shuffle=False,
                 generator=generator,
             )
         elif self.batch_size_type == "frame":
@@ -298,10 +282,9 @@ class TrainerConditioned:
         return dataloader_instance
 
     def remove_leading_value(self, generated, reference, value=0.0):
-        '''This removes the 'value' elements in the beginning of a melspectrogram'''
+        '''Removes leading rows of constant value from the beginning of a melspectrogram'''
         gen_flat = generated[0]
-        #reference_flat = reference[0]
-        
+
         is_row_of_ones = torch.all(gen_flat == value, dim=1)
         num_rows_to_remove = torch.sum(is_row_of_ones).item()
         
@@ -458,9 +441,6 @@ class TrainerConditioned:
         self.model.train()
 
     def train(self, train_dataset: Dataset, val_dataset: Dataset, faster_whisper_path, num_workers=16, resumable_with_seed: int = None, masking_type='original', **kwargs):
-        print("01 self.optimizer.param_groups[0]['lr']: ", self.optimizer.param_groups[0]['lr'])
-
-        
         if self.log_samples:
             from f5_tts.infer.utils_infer import cfg_strength, load_vocoder, nfe_step, sway_sampling_coef
 
@@ -468,10 +448,8 @@ class TrainerConditioned:
             target_sample_rate = self.accelerator.unwrap_model(self.model).mel_spec.target_sample_rate
             log_samples_path = f"{self.checkpoint_path}/samples_train_sample"
             val_samples_path = f"{self.checkpoint_path}/samples_val"
-            # forward_samples_path = f"{self.checkpoint_path}/samples_train_forward"
             os.makedirs(log_samples_path, exist_ok=True)
             os.makedirs(val_samples_path, exist_ok=True)
-            # os.makedirs(forward_samples_path, exist_ok=True)
 
         if exists(resumable_with_seed):
             generator = torch.Generator()
@@ -647,8 +625,6 @@ class TrainerConditioned:
                     if self.logger == "tensorboard":
                         self.writer.add_scalar("loss", loss.item(), global_step)
                         self.writer.add_scalar("lr", self.scheduler.get_last_lr()[0], global_step)
-                        # if global_step % 1 == 0:
-                        #     self.writer.add_scalar("RAM", get_memory_usage(), global_step)
 
                 progress_bar.set_postfix(step=str(global_step), loss=loss.item())
 

--- a/src/f5_tts/model/trainer_emotion.py
+++ b/src/f5_tts/model/trainer_emotion.py
@@ -498,17 +498,19 @@ class TrainerConditioned:
 
         freeze_backbone = kwargs['freeze_backbone']
         if freeze_backbone:
-            #if kwargs['emotion_conditioning']['emotion_condition_type'] == 'text_mirror':
-                print('Freezing network 🧊 ...')
-                # Freeze all parameters in self.model.transformer
-                for param in self.model.transformer.parameters():
-                    param.requires_grad = False
+            print('Freezing backbone ...')
+            for param in self.model.transformer.parameters():
+                param.requires_grad = False
 
-                # Unfreeze the parameters of input_embed and emotion_embed
-                for param in self.model.transformer.input_embed.parameters():
-                    param.requires_grad = True
+            # Unfreeze emotion-related parameters
+            for param in self.model.transformer.input_embed.parameters():
+                param.requires_grad = True
 
-                for param in self.model.transformer.emotion_embed.parameters():
+            for param in self.model.transformer.emotion_embed.parameters():
+                param.requires_grad = True
+
+            if kwargs['emotion_conditioning']['emotion_condition_type'] == 'film':
+                for param in self.model.transformer.emotion_film_blocks.parameters():
                     param.requires_grad = True
 
         for epoch in range(skipped_epoch, self.epochs):

--- a/src/f5_tts/model/utils.py
+++ b/src/f5_tts/model/utils.py
@@ -109,7 +109,6 @@ def get_tokenizer(dataset_name, tokenizer: str = "pinyin"):
                 - if use "byte", set to 256 (unicode byte range)
     """
     if tokenizer in ["pinyin", "char"]:
-        #tokenizer_path = os.path.join(files("f5_tts").joinpath("../../data"), f"{dataset_name}_{tokenizer}/vocab.txt")
         tokenizer_path = os.path.join('data', f"{dataset_name}_{tokenizer}/vocab.txt")
         with open(tokenizer_path, "r", encoding="utf-8") as f:
             vocab_char_map = {}

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -1,0 +1,117 @@
+"""Balance a descriptor JSON so each label contributes the same number of records.
+
+Operates on the output of prepare_generic_dataset.py (or any descriptor whose
+records carry an "emotion" field).
+"""
+
+import argparse
+import json
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    for key in TOP_KEYS:
+        if key in data:
+            return key, data[key]
+    raise SystemExit(f"Descriptor {path} has no top key in {TOP_KEYS}.")
+
+
+def _group_by_label(records):
+    groups = defaultdict(list)
+    for r in records:
+        groups[r["emotion"]].append(r)
+    return groups
+
+
+def _resolve_target(groups, strategy, explicit):
+    counts = {lbl: len(rs) for lbl, rs in groups.items()}
+    if explicit is not None:
+        return explicit
+    if strategy == "undersample":
+        return min(counts.values())
+    if strategy == "oversample":
+        return max(counts.values())
+    if strategy == "median":
+        sorted_counts = sorted(counts.values())
+        return sorted_counts[len(sorted_counts) // 2]
+    raise SystemExit(f"Unknown strategy {strategy!r}")
+
+
+def balance(records, strategy, target_count, seed):
+    rng = random.Random(seed)
+    groups = _group_by_label(records)
+    target = _resolve_target(groups, strategy, target_count)
+
+    balanced = []
+    per_label_final = Counter()
+    for label, items in groups.items():
+        if len(items) >= target:
+            picked = rng.sample(items, target)
+        else:
+            picked = list(items)
+            picked.extend(rng.choices(items, k=target - len(items)))
+        balanced.extend(picked)
+        per_label_final[label] = len(picked)
+
+    rng.shuffle(balanced)
+    return balanced, per_label_final, target
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input", required=True, help="Source descriptor JSON.")
+    p.add_argument("--output", required=True, help="Where to write the balanced descriptor.")
+    p.add_argument("--strategy", default="undersample",
+                   choices=["undersample", "oversample", "median"],
+                   help="How to pick the per-label target count if --target-count is unset.")
+    p.add_argument("--target-count", type=int, default=None,
+                   help="Explicit per-label sample count. Overrides --strategy.")
+    p.add_argument("--seed", type=int, default=0,
+                   help="RNG seed for sampling reproducibility.")
+    p.add_argument("--update-labels-file", default=None,
+                   help="Optional path to a labels.json to rewrite with the new counts.")
+    args = p.parse_args()
+
+    top_key, records = _load(args.input)
+    print(f"Loaded {len(records)} records under top key {top_key!r}")
+    print("Original counts:")
+    for lbl, n in Counter(r["emotion"] for r in records).most_common():
+        print(f"  {lbl:40s} {n}")
+
+    balanced, per_label_final, target = balance(
+        records, args.strategy, args.target_count, args.seed
+    )
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({top_key: balanced}, f, ensure_ascii=False, indent=2)
+
+    print(f"\nWrote {len(balanced)} records (target={target}) → {out_path}")
+    print("Balanced counts:")
+    for lbl, n in per_label_final.most_common():
+        print(f"  {lbl:40s} {n}")
+
+    if args.update_labels_file:
+        labels_path = Path(args.update_labels_file)
+        if labels_path.exists():
+            with open(labels_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        else:
+            meta = {}
+        meta["labels"] = sorted(per_label_final)
+        meta["counts"] = dict(per_label_final.most_common())
+        with open(labels_path, "w", encoding="utf-8") as f:
+            json.dump(meta, f, ensure_ascii=False, indent=2)
+        print(f"Updated label vocab → {labels_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -37,10 +37,10 @@ def _load_many(paths):
     return sorted(top_keys_seen)[0], merged
 
 
-def _group_by_label(records):
+def _group_by_label(records, field):
     groups = defaultdict(list)
     for r in records:
-        groups[r["emotion"]].append(r)
+        groups[r[field]].append(r)
     return groups
 
 
@@ -58,9 +58,9 @@ def _resolve_target(groups, strategy, explicit):
     raise SystemExit(f"Unknown strategy {strategy!r}")
 
 
-def balance(records, strategy, target_count, seed):
+def balance(records, strategy, target_count, seed, field):
     rng = random.Random(seed)
-    groups = _group_by_label(records)
+    groups = _group_by_label(records, field)
     target = _resolve_target(groups, strategy, target_count)
 
     balanced = []
@@ -98,6 +98,8 @@ def main():
                    help="RNG seed for sampling reproducibility.")
     p.add_argument("--update-labels-file", default=None,
                    help="Optional path to a labels.json to rewrite with the new counts.")
+    p.add_argument("--label-field", default="emotion",
+                   help="Record field naming the label (default: emotion).")
     args = p.parse_args()
 
     print(f"Loading {len(args.input)} descriptor(s):")
@@ -108,20 +110,21 @@ def main():
         top_key = args.top_key
     print(f"Merged {len(records)} records; output top key = {top_key!r}")
 
+    field = args.label_field
     if args.labels:
         wanted = {s.strip() for s in args.labels.split(",") if s.strip()}
         before = len(records)
-        records = [r for r in records if r["emotion"] in wanted]
+        records = [r for r in records if r[field] in wanted]
         print(f"Filtered to {len(wanted)} label(s): kept {len(records)}/{before}")
-        missing = wanted - {r["emotion"] for r in records}
+        missing = wanted - {r[field] for r in records}
         if missing:
             print(f"Warning: no records found for labels: {sorted(missing)}")
     print("Original counts:")
-    for lbl, n in Counter(r["emotion"] for r in records).most_common():
+    for lbl, n in Counter(r[field] for r in records).most_common():
         print(f"  {lbl:40s} {n}")
 
     balanced, per_label_final, target = balance(
-        records, args.strategy, args.target_count, args.seed
+        records, args.strategy, args.target_count, args.seed, field
     )
 
     out_path = Path(args.output)

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -15,6 +15,18 @@ TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
 
 
 def _load(path):
+    if path.endswith(".jsonl"):
+        records = []
+        with open(path, "r", encoding="utf-8") as f:
+            for i, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    raise SystemExit(f"{path}:{i}: invalid JSON line ({e})")
+        return None, records
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     for key in TOP_KEYS:
@@ -28,13 +40,15 @@ def _load_many(paths):
     top_keys_seen = set()
     for path in paths:
         key, records = _load(path)
-        top_keys_seen.add(key)
+        if key is not None:
+            top_keys_seen.add(key)
         print(f"  {path}: {len(records)} records under {key!r}")
         merged.extend(records)
     if len(top_keys_seen) > 1:
         print(f"Note: inputs use different top keys {top_keys_seen}; "
               f"output will use {sorted(top_keys_seen)[0]!r}")
-    return sorted(top_keys_seen)[0], merged
+    top_key = sorted(top_keys_seen)[0] if top_keys_seen else None
+    return top_key, merged
 
 
 def _group_by_label(records, field):
@@ -108,6 +122,12 @@ def main():
         if args.top_key not in TOP_KEYS:
             raise SystemExit(f"--top-key must be one of {TOP_KEYS} (got {args.top_key!r})")
         top_key = args.top_key
+    out_path = Path(args.output)
+    if top_key is None and not out_path.name.endswith(".jsonl"):
+        raise SystemExit(
+            "Inputs are JSONL (no top key); pass --top-key for JSON output "
+            "or use a .jsonl --output path."
+        )
     print(f"Merged {len(records)} records; output top key = {top_key!r}")
 
     field = args.label_field
@@ -127,10 +147,13 @@ def main():
         records, args.strategy, args.target_count, args.seed, field
     )
 
-    out_path = Path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with open(out_path, "w", encoding="utf-8") as f:
-        json.dump({top_key: balanced}, f, ensure_ascii=False, indent=2)
+        if out_path.name.endswith(".jsonl"):
+            for r in balanced:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        else:
+            json.dump({top_key: balanced}, f, ensure_ascii=False, indent=2)
 
     print(f"\nWrote {len(balanced)} records (target={target}) → {out_path}")
     print("Balanced counts:")

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -86,6 +86,9 @@ def main():
                    help="Override the top-level key written to --output "
                         "(must be one of ESD/RAVDESS/CREMA-D).")
     p.add_argument("--output", required=True, help="Where to write the balanced descriptor.")
+    p.add_argument("--labels", default=None,
+                   help="Comma-separated whitelist of labels to keep. "
+                        "Records with other labels are dropped before balancing.")
     p.add_argument("--strategy", default="undersample",
                    choices=["undersample", "oversample", "median"],
                    help="How to pick the per-label target count if --target-count is unset.")
@@ -104,6 +107,15 @@ def main():
             raise SystemExit(f"--top-key must be one of {TOP_KEYS} (got {args.top_key!r})")
         top_key = args.top_key
     print(f"Merged {len(records)} records; output top key = {top_key!r}")
+
+    if args.labels:
+        wanted = {s.strip() for s in args.labels.split(",") if s.strip()}
+        before = len(records)
+        records = [r for r in records if r["emotion"] in wanted]
+        print(f"Filtered to {len(wanted)} label(s): kept {len(records)}/{before}")
+        missing = wanted - {r["emotion"] for r in records}
+        if missing:
+            print(f"Warning: no records found for labels: {sorted(missing)}")
     print("Original counts:")
     for lbl, n in Counter(r["emotion"] for r in records).most_common():
         print(f"  {lbl:40s} {n}")

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -42,7 +42,9 @@ def _load_many(paths):
         key, records = _load(path)
         if key is not None:
             top_keys_seen.add(key)
-        print(f"  {path}: {len(records)} records under {key!r}")
+            print(f"  {path}: {len(records)} records under {key!r}")
+        else:
+            print(f"  {path}: {len(records)} records (jsonl)")
         merged.extend(records)
     if len(top_keys_seen) > 1:
         print(f"Note: inputs use different top keys {top_keys_seen}; "

--- a/src/f5_tts/train/datasets/balance_dataset.py
+++ b/src/f5_tts/train/datasets/balance_dataset.py
@@ -23,6 +23,20 @@ def _load(path):
     raise SystemExit(f"Descriptor {path} has no top key in {TOP_KEYS}.")
 
 
+def _load_many(paths):
+    merged = []
+    top_keys_seen = set()
+    for path in paths:
+        key, records = _load(path)
+        top_keys_seen.add(key)
+        print(f"  {path}: {len(records)} records under {key!r}")
+        merged.extend(records)
+    if len(top_keys_seen) > 1:
+        print(f"Note: inputs use different top keys {top_keys_seen}; "
+              f"output will use {sorted(top_keys_seen)[0]!r}")
+    return sorted(top_keys_seen)[0], merged
+
+
 def _group_by_label(records):
     groups = defaultdict(list)
     for r in records:
@@ -66,7 +80,11 @@ def balance(records, strategy, target_count, seed):
 
 def main():
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--input", required=True, help="Source descriptor JSON.")
+    p.add_argument("--input", required=True, nargs="+",
+                   help="One or more source descriptor JSONs. Records are merged before balancing.")
+    p.add_argument("--top-key", default=None,
+                   help="Override the top-level key written to --output "
+                        "(must be one of ESD/RAVDESS/CREMA-D).")
     p.add_argument("--output", required=True, help="Where to write the balanced descriptor.")
     p.add_argument("--strategy", default="undersample",
                    choices=["undersample", "oversample", "median"],
@@ -79,8 +97,13 @@ def main():
                    help="Optional path to a labels.json to rewrite with the new counts.")
     args = p.parse_args()
 
-    top_key, records = _load(args.input)
-    print(f"Loaded {len(records)} records under top key {top_key!r}")
+    print(f"Loading {len(args.input)} descriptor(s):")
+    top_key, records = _load_many(args.input)
+    if args.top_key:
+        if args.top_key not in TOP_KEYS:
+            raise SystemExit(f"--top-key must be one of {TOP_KEYS} (got {args.top_key!r})")
+        top_key = args.top_key
+    print(f"Merged {len(records)} records; output top key = {top_key!r}")
     print("Original counts:")
     for lbl, n in Counter(r["emotion"] for r in records).most_common():
         print(f"  {lbl:40s} {n}")

--- a/src/f5_tts/train/datasets/inspect_dataset.py
+++ b/src/f5_tts/train/datasets/inspect_dataset.py
@@ -13,6 +13,18 @@ TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
 
 
 def _load(path):
+    if path.endswith(".jsonl"):
+        records = []
+        with open(path, "r", encoding="utf-8") as f:
+            for i, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    raise SystemExit(f"{path}:{i}: invalid JSON line ({e})")
+        return path, records
     with open(path, "r", encoding="utf-8") as f:
         data = json.load(f)
     for key in TOP_KEYS:

--- a/src/f5_tts/train/datasets/inspect_dataset.py
+++ b/src/f5_tts/train/datasets/inspect_dataset.py
@@ -1,0 +1,84 @@
+"""Print per-label sample counts for one or more descriptor JSONs.
+
+Useful before running balance_dataset.py to decide on a target count, label
+whitelist, or strategy.
+"""
+
+import argparse
+import json
+from collections import Counter
+
+
+TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
+
+
+def _load(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    for key in TOP_KEYS:
+        if key in data:
+            return key, data[key]
+    raise SystemExit(f"Descriptor {path} has no top key in {TOP_KEYS}.")
+
+
+def _print_table(counts, total):
+    if not counts:
+        print("  (empty)")
+        return
+    width = max(len(lbl) for lbl in counts)
+    for lbl, n in counts.most_common():
+        pct = 100.0 * n / total if total else 0.0
+        print(f"  {lbl:<{width}}  {n:>8d}  {pct:5.1f}%")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input", required=True, nargs="+",
+                   help="One or more descriptor JSONs.")
+    p.add_argument("--merged-only", action="store_true",
+                   help="Skip per-file breakdown; print only merged totals.")
+    p.add_argument("--json", action="store_true",
+                   help="Emit counts as JSON instead of a table.")
+    args = p.parse_args()
+
+    per_file = {}
+    merged = Counter()
+    for path in args.input:
+        _, records = _load(path)
+        c = Counter(r["emotion"] for r in records)
+        per_file[path] = c
+        merged.update(c)
+
+    if args.json:
+        print(json.dumps(
+            {
+                "per_file": {p: dict(c.most_common()) for p, c in per_file.items()},
+                "merged": dict(merged.most_common()),
+                "total": sum(merged.values()),
+                "num_labels": len(merged),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ))
+        return
+
+    if not args.merged_only and len(args.input) > 1:
+        for path, c in per_file.items():
+            total = sum(c.values())
+            print(f"\n{path}  ({total} records, {len(c)} labels)")
+            _print_table(c, total)
+
+    total = sum(merged.values())
+    header = "Merged" if len(args.input) > 1 else args.input[0]
+    print(f"\n{header}  ({total} records, {len(merged)} labels)")
+    _print_table(merged, total)
+
+    if merged:
+        counts = list(merged.values())
+        print(f"\nmin={min(counts)}  max={max(counts)}  "
+              f"mean={sum(counts)/len(counts):.1f}  "
+              f"imbalance={max(counts)/min(counts):.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/f5_tts/train/datasets/inspect_dataset.py
+++ b/src/f5_tts/train/datasets/inspect_dataset.py
@@ -10,6 +10,7 @@ from collections import Counter
 
 
 TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
+LABEL_FIELDS = ("emotion", "label")
 
 
 def _load(path):
@@ -51,13 +52,23 @@ def main():
                    help="Skip per-file breakdown; print only merged totals.")
     p.add_argument("--json", action="store_true",
                    help="Emit counts as JSON instead of a table.")
+    p.add_argument("--label-field", default=None,
+                   help=f"Record field to count. If unset, auto-detects from {LABEL_FIELDS}.")
     args = p.parse_args()
 
     per_file = {}
     merged = Counter()
     for path in args.input:
         _, records = _load(path)
-        c = Counter(r["emotion"] for r in records)
+        field = args.label_field or next(
+            (k for k in LABEL_FIELDS if records and k in records[0]), None
+        )
+        if field is None:
+            raise SystemExit(
+                f"{path}: no label field found (looked for {LABEL_FIELDS}); "
+                f"pass --label-field explicitly."
+            )
+        c = Counter(r[field] for r in records)
         per_file[path] = c
         merged.update(c)
 

--- a/src/f5_tts/train/datasets/prepare_generic_dataset.py
+++ b/src/f5_tts/train/datasets/prepare_generic_dataset.py
@@ -1,0 +1,160 @@
+"""Convert a generic JSON / JSONL metadata file into the descriptor format
+expected by CustomDatasetConditioned.
+
+The chosen --label-field is copied into the "emotion" key the loader reads,
+so any categorical attribute (persona, dialect, speaking rate, ...) can drive
+conditioning without touching the model code.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+
+def _iter_records(path):
+    with open(path, "r", encoding="utf-8") as f:
+        head = f.read(2048).lstrip()
+        f.seek(0)
+        if head.startswith("["):
+            for r in json.load(f):
+                yield r
+        else:
+            for line in f:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+
+
+def _get(row, dotted_key):
+    """Look up a possibly nested key, e.g. 'gemini_response_json.Persona'."""
+    cur = row
+    for part in dotted_key.split("."):
+        if isinstance(cur, str):
+            try:
+                cur = json.loads(cur)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _stable_speaker_id(row, speaker_field):
+    if speaker_field:
+        val = _get(row, speaker_field)
+        if val is not None:
+            return str(val)
+    audio = _get(row, "audio_path") or ""
+    parent = os.path.basename(os.path.dirname(audio)) or audio
+    return "spk_" + hashlib.md5(parent.encode("utf-8")).hexdigest()[:10]
+
+
+def build_descriptor(args):
+    records = []
+    skipped = Counter()
+    label_counts = Counter()
+
+    allowed = (
+        {s.strip() for s in args.allowed_labels.split(",") if s.strip()}
+        if args.allowed_labels
+        else None
+    )
+
+    for row in _iter_records(args.input):
+        audio = _get(row, args.audio_field)
+        text = _get(row, args.text_field)
+        label = _get(row, args.label_field)
+
+        if not audio or not text or label is None:
+            skipped["missing_field"] += 1
+            continue
+        label = str(label)
+        if allowed is not None and label not in allowed:
+            skipped["not_in_allowed_labels"] += 1
+            continue
+
+        label_counts[label] += 1
+        records.append(
+            {
+                "phrase_idx": str(_get(row, args.phrase_field) or len(records)),
+                "audio_path": audio,
+                "text": text,
+                "speaker_id": _stable_speaker_id(row, args.speaker_field),
+                "emotion": label,
+                "text_alignment": [],
+            }
+        )
+
+    if args.min_count > 1:
+        rare = {lbl for lbl, n in label_counts.items() if n < args.min_count}
+        if rare:
+            records = [r for r in records if r["emotion"] not in rare]
+            for lbl in rare:
+                skipped[f"min_count<{args.min_count}:{lbl}"] = label_counts.pop(lbl)
+
+    return records, label_counts, skipped
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input", required=True, help="JSON array or JSONL of metadata rows.")
+    p.add_argument("--output", required=True, help="Where to write the descriptor JSON.")
+    p.add_argument("--label-field", required=True,
+                   help="Field whose value becomes the categorical label (e.g. gemini_persona).")
+    p.add_argument("--text-field", default="text",
+                   help="Field with the transcript. Default: 'text'.")
+    p.add_argument("--audio-field", default="audio_path",
+                   help="Field with the absolute audio path. Default: 'audio_path'.")
+    p.add_argument("--speaker-field", default=None,
+                   help="Field with a speaker id. If absent, a hash of the audio dir is used.")
+    p.add_argument("--phrase-field", default=None,
+                   help="Field with a per-utterance id. If absent, the row index is used.")
+    p.add_argument("--allowed-labels", default=None,
+                   help="Comma-separated whitelist of labels to keep.")
+    p.add_argument("--min-count", type=int, default=1,
+                   help="Drop labels that occur fewer than this many times.")
+    p.add_argument("--top-key", default="ESD",
+                   help="Top-level key in the descriptor. Must be one of "
+                        "'ESD' / 'RAVDESS' / 'CREMA-D' (the loader's hard-coded set).")
+    args = p.parse_args()
+
+    if args.top_key not in {"ESD", "RAVDESS", "CREMA-D"}:
+        raise SystemExit(f"--top-key must be ESD, RAVDESS, or CREMA-D (got {args.top_key!r})")
+
+    records, label_counts, skipped = build_descriptor(args)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({args.top_key: records}, f, ensure_ascii=False, indent=2)
+
+    labels_path = out_path.parent / "labels.json"
+    with open(labels_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "label_field": args.label_field,
+                "labels": sorted(label_counts),
+                "counts": dict(label_counts.most_common()),
+            },
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    print(f"Wrote {len(records)} records → {out_path}")
+    print(f"Wrote label vocab ({len(label_counts)}) → {labels_path}")
+    print("Label counts:")
+    for lbl, n in label_counts.most_common():
+        print(f"  {lbl:40s} {n}")
+    if skipped:
+        print("Skipped:")
+        for k, n in skipped.items():
+            print(f"  {k:40s} {n}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/f5_tts/train/datasets/prepare_jsonl.py
+++ b/src/f5_tts/train/datasets/prepare_jsonl.py
@@ -1,15 +1,30 @@
-"""Convert a JSONL metadata file into F5-TTS training data (raw.arrow + duration.json + vocab.txt).
+"""Convert a JSONL metadata file into F5-TTS training data.
 
 Expected JSONL row:
     {"audio": "/abs/path/sample.wav", "text": "(Levantine)...", "duration": 3.9}
+
+The leading "(label)" tag is parsed out of the transcript: the stripped text is
+what gets written to the arrow dataset, and the captured label becomes the
+"emotion" field in a sibling descriptor.json consumed by CustomDatasetConditioned.
+
+Outputs in --out-dir:
+    raw.arrow        # {audio_path, text, duration} for the standard loader
+    duration.json    # durations list for DynamicBatchSampler
+    vocab.txt        # char vocab (or pretrained Emilia vocab when finetuning)
+    descriptor.json  # {top_key: [{audio_path, text, speaker_id, emotion, ...}]}
+    labels.json      # label vocab + counts
 
 Use --pinyin only for ZH/EN text; for other scripts (Arabic, etc.) leave it off
 so the transcript is tokenized as raw characters.
 """
 
 import argparse
+import hashlib
 import json
+import os
+import re
 import shutil
+from collections import Counter
 from importlib.resources import files
 from pathlib import Path
 
@@ -18,6 +33,8 @@ from datasets.arrow_writer import ArrowWriter
 
 
 PRETRAINED_VOCAB_PATH = files("f5_tts").joinpath("../../data/Emilia_ZH_EN_pinyin/vocab.txt")
+DESCRIPTOR_TOP_KEYS = ("ESD", "RAVDESS", "CREMA-D")
+LABEL_TAG_RE = re.compile(r"^\s*\(([^)]+)\)\s*")
 
 
 def iter_jsonl(path):
@@ -30,6 +47,19 @@ def iter_jsonl(path):
                 yield json.loads(line)
             except json.JSONDecodeError as e:
                 raise SystemExit(f"{path}:{i}: invalid JSON line ({e})")
+
+
+def split_label(text):
+    """Return (label, text_without_tag). label is None if no '(...)' prefix."""
+    m = LABEL_TAG_RE.match(text)
+    if not m:
+        return None, text
+    return m.group(1).strip(), text[m.end():]
+
+
+def speaker_id_for(audio_path):
+    parent = os.path.basename(os.path.dirname(audio_path)) or audio_path
+    return "spk_" + hashlib.md5(parent.encode("utf-8")).hexdigest()[:10]
 
 
 def build_records(
@@ -45,10 +75,13 @@ def build_records(
     if use_pinyin:
         from f5_tts.model.utils import convert_char_to_pinyin
 
-    records, durations, vocab = [], [], set()
+    arrow_records, descriptor_records, durations = [], [], []
+    vocab = set()
+    label_counts = Counter()
     skipped_missing_audio = 0
     skipped_missing_field = 0
     skipped_duration = 0
+    skipped_no_tag = 0
 
     for row in iter_jsonl(jsonl_path):
         audio = row.get(audio_field)
@@ -65,20 +98,45 @@ def build_records(
             skipped_missing_audio += 1
             continue
 
-        if use_pinyin:
-            text = convert_char_to_pinyin([text], polyphone=True)[0]
+        label, raw_text = split_label(text)
+        if label is None:
+            skipped_no_tag += 1
+            continue
 
-        records.append({"audio_path": audio, "text": text, "duration": dur})
+        arrow_text = convert_char_to_pinyin([raw_text], polyphone=True)[0] if use_pinyin else raw_text
+
+        arrow_records.append({"audio_path": audio, "text": arrow_text, "duration": dur})
+        descriptor_records.append({
+            "phrase_idx": str(len(descriptor_records)),
+            "audio_path": audio,
+            "text": raw_text,
+            "speaker_id": speaker_id_for(audio),
+            "emotion": label,
+            "text_alignment": [],
+        })
         durations.append(dur)
-        vocab.update(list(text))
+        vocab.update(list(arrow_text))
+        label_counts[label] += 1
 
-    return records, durations, vocab, skipped_missing_field, skipped_missing_audio, skipped_duration
+    return {
+        "arrow": arrow_records,
+        "descriptor": descriptor_records,
+        "durations": durations,
+        "vocab": vocab,
+        "label_counts": label_counts,
+        "skipped": {
+            "missing_field": skipped_missing_field,
+            "duration_out_of_range": skipped_duration,
+            "missing_audio": skipped_missing_audio,
+            "no_label_tag": skipped_no_tag,
+        },
+    }
 
 
-def save(out_dir, records, durations, vocab, is_finetune):
+def save_arrow(out_dir, records, durations, vocab, is_finetune):
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    print(f"\nSaving to {out_dir} ...")
+    print(f"\nSaving arrow dataset to {out_dir} ...")
 
     raw_arrow = out_dir / "raw.arrow"
     with ArrowWriter(path=raw_arrow.as_posix(), writer_batch_size=1) as writer:
@@ -99,15 +157,41 @@ def save(out_dir, records, durations, vocab, is_finetune):
                 f.write(v + "\n")
 
     name = out_dir.stem
-    print(f"\n[{name}] samples: {len(records)}")
+    print(f"[{name}] samples: {len(records)}")
     print(f"[{name}] vocab size: {len(vocab)}")
     print(f"[{name}] total duration: {sum(durations)/3600:.2f} h")
+
+
+def save_descriptor(out_dir, descriptor_records, label_counts, top_key):
+    out_dir = Path(out_dir)
+    descriptor_path = out_dir / "descriptor.json"
+    with open(descriptor_path, "w", encoding="utf-8") as f:
+        json.dump({top_key: descriptor_records}, f, ensure_ascii=False, indent=2)
+
+    labels_path = out_dir / "labels.json"
+    with open(labels_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "label_field": "emotion",
+                "labels": sorted(label_counts),
+                "counts": dict(label_counts.most_common()),
+            },
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    print(f"\nWrote descriptor ({len(descriptor_records)} records) → {descriptor_path}")
+    print(f"Wrote label vocab ({len(label_counts)}) → {labels_path}")
+    print("Label counts:")
+    for lbl, n in label_counts.most_common():
+        print(f"  {lbl:40s} {n}")
 
 
 def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--input", required=True, help="Input JSONL file.")
-    p.add_argument("--out-dir", required=True, help="Output directory for raw.arrow / duration.json / vocab.txt.")
+    p.add_argument("--out-dir", required=True, help="Output directory.")
     p.add_argument("--audio-field", default="audio")
     p.add_argument("--text-field", default="text")
     p.add_argument("--duration-field", default="duration")
@@ -121,9 +205,13 @@ def main():
                    help="Drop rows with duration <= this (seconds). Default: 3.0.")
     p.add_argument("--max-duration", type=float, default=15.0,
                    help="Drop rows with duration >= this (seconds). Default: 15.0.")
+    p.add_argument("--top-key", default="ESD", choices=DESCRIPTOR_TOP_KEYS,
+                   help="Top-level key in descriptor.json (loader hard-codes this set). Default: ESD.")
+    p.add_argument("--no-descriptor", action="store_true",
+                   help="Skip writing descriptor.json / labels.json.")
     args = p.parse_args()
 
-    records, durations, vocab, skipped_field, skipped_audio, skipped_duration = build_records(
+    out = build_records(
         args.input,
         args.audio_field,
         args.text_field,
@@ -134,17 +222,22 @@ def main():
         max_duration=args.max_duration,
     )
 
-    if skipped_field:
-        print(f"Skipped {skipped_field} rows missing required field(s).")
-    if skipped_duration:
-        print(f"Skipped {skipped_duration} rows outside duration "
+    skipped = out["skipped"]
+    if skipped["missing_field"]:
+        print(f"Skipped {skipped['missing_field']} rows missing required field(s).")
+    if skipped["duration_out_of_range"]:
+        print(f"Skipped {skipped['duration_out_of_range']} rows outside duration "
               f"({args.min_duration}, {args.max_duration})s.")
-    if skipped_audio:
-        print(f"Skipped {skipped_audio} rows whose audio file was not found.")
-    if not records:
+    if skipped["missing_audio"]:
+        print(f"Skipped {skipped['missing_audio']} rows whose audio file was not found.")
+    if skipped["no_label_tag"]:
+        print(f"Skipped {skipped['no_label_tag']} rows with no leading '(label)' tag.")
+    if not out["arrow"]:
         raise SystemExit("No usable records.")
 
-    save(args.out_dir, records, durations, vocab, is_finetune=not args.pretrain)
+    save_arrow(args.out_dir, out["arrow"], out["durations"], out["vocab"], is_finetune=not args.pretrain)
+    if not args.no_descriptor:
+        save_descriptor(args.out_dir, out["descriptor"], out["label_counts"], args.top_key)
 
 
 if __name__ == "__main__":

--- a/src/f5_tts/train/datasets/prepare_jsonl.py
+++ b/src/f5_tts/train/datasets/prepare_jsonl.py
@@ -1,0 +1,151 @@
+"""Convert a JSONL metadata file into F5-TTS training data (raw.arrow + duration.json + vocab.txt).
+
+Expected JSONL row:
+    {"audio": "/abs/path/sample.wav", "text": "(Levantine)...", "duration": 3.9}
+
+Use --pinyin only for ZH/EN text; for other scripts (Arabic, etc.) leave it off
+so the transcript is tokenized as raw characters.
+"""
+
+import argparse
+import json
+import shutil
+from importlib.resources import files
+from pathlib import Path
+
+from tqdm import tqdm
+from datasets.arrow_writer import ArrowWriter
+
+
+PRETRAINED_VOCAB_PATH = files("f5_tts").joinpath("../../data/Emilia_ZH_EN_pinyin/vocab.txt")
+
+
+def iter_jsonl(path):
+    with open(path, "r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"{path}:{i}: invalid JSON line ({e})")
+
+
+def build_records(
+    jsonl_path,
+    audio_field,
+    text_field,
+    duration_field,
+    use_pinyin,
+    check_exists,
+    min_duration,
+    max_duration,
+):
+    if use_pinyin:
+        from f5_tts.model.utils import convert_char_to_pinyin
+
+    records, durations, vocab = [], [], set()
+    skipped_missing_audio = 0
+    skipped_missing_field = 0
+    skipped_duration = 0
+
+    for row in iter_jsonl(jsonl_path):
+        audio = row.get(audio_field)
+        text = row.get(text_field)
+        dur = row.get(duration_field)
+        if not audio or not text or dur is None:
+            skipped_missing_field += 1
+            continue
+        dur = float(dur)
+        if dur <= min_duration or dur >= max_duration:
+            skipped_duration += 1
+            continue
+        if check_exists and not Path(audio).exists():
+            skipped_missing_audio += 1
+            continue
+
+        if use_pinyin:
+            text = convert_char_to_pinyin([text], polyphone=True)[0]
+
+        records.append({"audio_path": audio, "text": text, "duration": dur})
+        durations.append(dur)
+        vocab.update(list(text))
+
+    return records, durations, vocab, skipped_missing_field, skipped_missing_audio, skipped_duration
+
+
+def save(out_dir, records, durations, vocab, is_finetune):
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"\nSaving to {out_dir} ...")
+
+    raw_arrow = out_dir / "raw.arrow"
+    with ArrowWriter(path=raw_arrow.as_posix(), writer_batch_size=1) as writer:
+        for r in tqdm(records, desc="Writing raw.arrow"):
+            writer.write(r)
+
+    with open(out_dir / "duration.json", "w", encoding="utf-8") as f:
+        json.dump({"duration": durations}, f, ensure_ascii=False)
+
+    vocab_path = out_dir / "vocab.txt"
+    if is_finetune:
+        if not PRETRAINED_VOCAB_PATH.exists():
+            raise SystemExit(f"pretrained vocab.txt not found: {PRETRAINED_VOCAB_PATH}")
+        shutil.copy2(PRETRAINED_VOCAB_PATH.as_posix(), vocab_path)
+    else:
+        with open(vocab_path, "w", encoding="utf-8") as f:
+            for v in sorted(vocab):
+                f.write(v + "\n")
+
+    name = out_dir.stem
+    print(f"\n[{name}] samples: {len(records)}")
+    print(f"[{name}] vocab size: {len(vocab)}")
+    print(f"[{name}] total duration: {sum(durations)/3600:.2f} h")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--input", required=True, help="Input JSONL file.")
+    p.add_argument("--out-dir", required=True, help="Output directory for raw.arrow / duration.json / vocab.txt.")
+    p.add_argument("--audio-field", default="audio")
+    p.add_argument("--text-field", default="text")
+    p.add_argument("--duration-field", default="duration")
+    p.add_argument("--pinyin", action="store_true",
+                   help="Apply ZH/EN pinyin conversion to text. Leave off for Arabic / other scripts.")
+    p.add_argument("--pretrain", action="store_true",
+                   help="Write a fresh vocab.txt from the data. Default copies the pretrained Emilia vocab (finetune).")
+    p.add_argument("--check-audio-exists", action="store_true",
+                   help="Stat every audio path and skip rows whose file is missing.")
+    p.add_argument("--min-duration", type=float, default=3.0,
+                   help="Drop rows with duration <= this (seconds). Default: 3.0.")
+    p.add_argument("--max-duration", type=float, default=15.0,
+                   help="Drop rows with duration >= this (seconds). Default: 15.0.")
+    args = p.parse_args()
+
+    records, durations, vocab, skipped_field, skipped_audio, skipped_duration = build_records(
+        args.input,
+        args.audio_field,
+        args.text_field,
+        args.duration_field,
+        use_pinyin=args.pinyin,
+        check_exists=args.check_audio_exists,
+        min_duration=args.min_duration,
+        max_duration=args.max_duration,
+    )
+
+    if skipped_field:
+        print(f"Skipped {skipped_field} rows missing required field(s).")
+    if skipped_duration:
+        print(f"Skipped {skipped_duration} rows outside duration "
+              f"({args.min_duration}, {args.max_duration})s.")
+    if skipped_audio:
+        print(f"Skipped {skipped_audio} rows whose audio file was not found.")
+    if not records:
+        raise SystemExit("No usable records.")
+
+    save(args.out_dir, records, durations, vocab, is_finetune=not args.pretrain)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/f5_tts/train/train_emotion.py
+++ b/src/f5_tts/train/train_emotion.py
@@ -1,15 +1,12 @@
 # training script.
 
-from importlib.resources import files
+import copy
 
-#from f5_tts.model import CFM, DiT, UNetT # old version without emotion conditioning
-from f5_tts.model import CFMConditioned, DiTConditioned, UNetT # new version, with emotion conditioning
+from f5_tts.model import CFMConditioned, DiTConditioned, UNetT
 from f5_tts.model.dataset import load_dataset
 from f5_tts.model.utils import get_tokenizer
 from f5_tts.model.trainer_emotion import TrainerConditioned
 from torch.utils.data import ConcatDataset
-
-import copy
 
 
 #-------------------------- Dataset Settings --------------------------- #
@@ -27,9 +24,6 @@ tokenizer_path = None  # if tokenizer = 'custom', define the path to the tokeniz
 #dataset_name = "Emilia_ZH_EN"
 train_dataset_name = "EmiliaPetite_dataset_ZH_EN"
 val_dataset_name = 'EmiliaPetite_dataset_ZH_EN_val'
-
-# train_dataset_path_esd = 'dataset/Emotional Speech Dataset (ESD)/train/dataset_descriptor.json' # ESD
-# train_dataset_path_ravdess = 'dataset/RAVDESS/ravdess_metadata.json' # RAVDESS
 
 val_dataset_path = 'dataset/ESD/val/dataset_descriptor.json'
 
@@ -49,7 +43,6 @@ checkpoint_path = f"ckpts/{exp_name}"
 
 learning_rate = 1e-5
 
-batch_size_per_gpu = 384
 batch_size_per_gpu = 2
 batch_size_type = "sample"  # "frame" or "sample". Only "sample" is supported by the dataset_type="CustomDatasetConditioned"
 max_samples = 64  # max sequences per batch if use frame-wise batch_size.
@@ -71,7 +64,6 @@ training_config = {
     'compute_wer_valid': False,
     'compute_mcd_valid': False,
     'dataset_keys': ['ESD'],
-    #'masking_type': 'original',
     'masking_type': '2nd_part_proportional_masked',
 
     'change_emotion_forward': False,
@@ -79,48 +71,25 @@ training_config = {
     'noise_2ndhalf': 'uniform', # other otpions than 'uniform' are proven o cause probelms at sample()
 
     # -----------------------
-    # I) 'emotion_condition_type' 🎭
-    # V0) Non-emotional
-    # 'emotion_conditioning': {
-    #     'emotion_condition_type': 'no_emotion_condition',
-    # },
-
-    # V1) text_mirror and late concatenation
+    # I) 'emotion_condition_type':
+    #   'no_emotion_condition' - baseline, no emotion signal
+    #   'text_early_fusion'   - adds emotion embedding to text embedding (scaled by 0.1)
+    #   'text_mirror'         - concatenates emotion to input projection
+    #   'film'                - per-layer FiLM modulation (scale+shift) after each DiT block
     'emotion_conditioning': {
-        'emotion_condition_type': 'text_mirror', 
-        'init_type': 'xavier_reduced', 
-        'weight_reduction_scale': 1, 
-        #'emotion_dim': 16,
+        'emotion_condition_type': 'film',
+        'emotion_dim': 512,
         'emotion_conv_layers': 4,
-        #'load_emotion_weights': True, # keep it True if not loading a modle that already has emotion conditioning. Make it False when loading a pretrained emotion model
-        'load_emotion_weights': False, # keep it True if not loading a modle that already has emotion conditioning. Make it False when loading a pretrained emotion model
+        'load_emotion_weights': False, # True when adapting a pretrained non-emotion model; False when resuming an emotion-aware checkpoint
     },
-
-    # V2) cross attnetion
-    # 'emotion_conditioning': {
-    #     'emotion_condition_type': 'cross_attention',
-    #     'emotion_dim': 1024,
-    #     'emotion_conv_layers': 4,
-    #     'load_emotion_weights': True
-    # },
-
-    # V3) text_early_fusion
-    # 'emotion_conditioning': {
-    #     'emotion_condition_type': 'text_early_fusion',
-    #     'emotion_dim': 128,
-    #     'emotion_conv_layers': 4,
-    #     'load_emotion_weights': True,
-    # },
 
     # -----------------------
     # II) Dataset parameters
     'emotion_conditioning_kwargs': {
-        'emotions': {"Angry", "Neutral", "Sad", "Surprise", "Happy"}, # This is all the dataset: all emotions
-        #'emotions': {"Sad", "Happy"}, # just 2 opposed emotoins
-        #'emotions': {"Sad", "Happy", "Neutral"}, # just 2 opposed emotoins + Neutral
-        'change_emotion_probability': 0.5, # If the emotion in the 1st and 2nd phrase differ .0 = never change emotion; 1 = always change emotion
-        'same_sentence': False, # if True, the 1st and 2nd sentence will be the same phrase, from the same actor, but with distinct emotions
-        'contrastive_loss': False, 
+        'emotions': {"Angry", "Neutral", "Sad", "Surprise", "Happy"},
+        'change_emotion_probability': 0.5,
+        'same_sentence': False,
+        'contrastive_loss': False,
     }
 }
 
@@ -130,10 +99,15 @@ emotion_conditioning_val_kwargs['contrastive_loss'] = False
 
 
 # model params
+emotion_cfg = training_config['emotion_conditioning']
 if "F5TTS_Base" in exp_name:
     wandb_resume_id = None
     model_cls = DiTConditioned
-    model_cfg = dict(dim=1024, depth=22, heads=16, ff_mult=2, text_dim=512, emotion_dim=training_config['emotion_conditioning']['emotion_dim'], conv_layers=training_config['emotion_conditioning']['emotion_conv_layers'])
+    model_cfg = dict(
+        dim=1024, depth=22, heads=16, ff_mult=2, text_dim=512,
+        emotion_dim=emotion_cfg.get('emotion_dim', 100),
+        conv_layers=emotion_cfg.get('emotion_conv_layers', 0),
+    )
 elif exp_name == "E2TTS_Base":
     wandb_resume_id = None
     model_cls = UNetT
@@ -144,12 +118,8 @@ elif exp_name == "E2TTS_Base":
 
 
 def main():
-    if tokenizer == "custom":
-        tokenizer_path = tokenizer_path
-    else:
-        tokenizer_path = train_dataset_name
-
-    vocab_char_map, vocab_size = get_tokenizer(tokenizer_path, tokenizer)
+    tok_path = tokenizer_path if tokenizer == "custom" else train_dataset_name
+    vocab_char_map, vocab_size = get_tokenizer(tok_path, tokenizer)
 
     mel_spec_kwargs = dict(
         n_fft=n_fft,
@@ -172,7 +142,6 @@ def main():
         learning_rate,
         num_warmup_updates=2,
         save_per_updates=save_per_updates,
-        #checkpoint_path=str(files("f5_tts").joinpath(f"../../ckpts/{exp_name}")),
         checkpoint_path=checkpoint_path,
         batch_size=batch_size_per_gpu,
         batch_size_type=batch_size_type,

--- a/src/f5_tts/train/train_emotion.py
+++ b/src/f5_tts/train/train_emotion.py
@@ -1,12 +1,38 @@
 # training script.
 
+import argparse
 import copy
+import json
 
 from f5_tts.model import CFMConditioned, DiTConditioned, UNetT
 from f5_tts.model.dataset import load_dataset
 from f5_tts.model.utils import get_tokenizer
 from f5_tts.model.trainer_emotion import TrainerConditioned
 from torch.utils.data import ConcatDataset
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(
+        description="Finetune F5-TTS with categorical conditioning. "
+                    "Defaults match the in-file config; CLI flags override.",
+        allow_abbrev=False,
+    )
+    p.add_argument("--train-descriptor", default=None,
+                   help="Path to a single training descriptor JSON. "
+                        "Overrides train_dataset_paths and forces dataset_keys=['ESD'].")
+    p.add_argument("--val-descriptor", default=None,
+                   help="Path to the validation descriptor JSON.")
+    p.add_argument("--labels-file", default=None,
+                   help="Path to a labels.json (from prepare_generic_dataset.py) "
+                        "whose 'labels' list becomes the conditioning vocabulary.")
+    p.add_argument("--labels", default=None,
+                   help="Comma-separated label set. Overrides --labels-file.")
+    p.add_argument("--change-label-prob", type=float, default=None,
+                   help="Probability of sampling a second clip with a different label. "
+                        "Set 0.0 for non-parallel datasets (default in-file: 0.5).")
+    p.add_argument("--checkpoint-path", default=None,
+                   help="Override the checkpoint directory.")
+    return p.parse_args()
 
 
 #-------------------------- Dataset Settings --------------------------- #
@@ -93,11 +119,6 @@ training_config = {
     }
 }
 
-emotion_conditioning_kwargs = copy.deepcopy(training_config['emotion_conditioning_kwargs'])
-emotion_conditioning_val_kwargs = copy.deepcopy(training_config['emotion_conditioning_kwargs'])
-emotion_conditioning_val_kwargs['contrastive_loss'] = False
-
-
 # model params
 emotion_cfg = training_config['emotion_conditioning']
 if "F5TTS_Base" in exp_name:
@@ -118,6 +139,34 @@ elif exp_name == "E2TTS_Base":
 
 
 def main():
+    cli = _parse_args()
+
+    if cli.labels is not None:
+        training_config['emotion_conditioning_kwargs']['emotions'] = {
+            s.strip() for s in cli.labels.split(",") if s.strip()
+        }
+    elif cli.labels_file is not None:
+        with open(cli.labels_file, "r", encoding="utf-8") as f:
+            training_config['emotion_conditioning_kwargs']['emotions'] = set(json.load(f)["labels"])
+
+    if cli.change_label_prob is not None:
+        training_config['emotion_conditioning_kwargs']['change_emotion_probability'] = cli.change_label_prob
+
+    if cli.train_descriptor is not None:
+        train_dataset_paths.clear()
+        train_dataset_paths['ESD'] = cli.train_descriptor
+        training_config['dataset_keys'] = ['ESD']
+
+    if cli.val_descriptor is not None:
+        global val_dataset_path
+        val_dataset_path = cli.val_descriptor
+
+    ckpt_dir = cli.checkpoint_path or checkpoint_path
+
+    emotion_conditioning_kwargs = copy.deepcopy(training_config['emotion_conditioning_kwargs'])
+    emotion_conditioning_val_kwargs = copy.deepcopy(training_config['emotion_conditioning_kwargs'])
+    emotion_conditioning_val_kwargs['contrastive_loss'] = False
+
     tok_path = tokenizer_path if tokenizer == "custom" else train_dataset_name
     vocab_char_map, vocab_size = get_tokenizer(tok_path, tokenizer)
 
@@ -142,7 +191,7 @@ def main():
         learning_rate,
         num_warmup_updates=2,
         save_per_updates=save_per_updates,
-        checkpoint_path=checkpoint_path,
+        checkpoint_path=ckpt_dir,
         batch_size=batch_size_per_gpu,
         batch_size_type=batch_size_type,
         max_samples=max_samples,


### PR DESCRIPTION
## Summary
- Wire `EmotionFiLM` (per-layer scale+shift modulation) end-to-end as a new `emotion_condition_type='film'` option — zero-initialized output projection makes it safe for finetuning from a pretrained checkpoint
- Fix `drop_emotion_cond` hardcoded to `False` in `cfm_emotion.py` which silently disabled emotion CFG during training — emotion was never dropped, so the model couldn't learn the unconditional baseline needed for dual-CFG (`cfg_strength2`) at inference
- Update `freeze_backbone` in `trainer_emotion.py` to unfreeze `emotion_film_blocks` when using FiLM
- Fix bugs in `train_emotion.py`: `tokenizer_path` self-assignment, `emotion_dim` KeyError, duplicate batch_size, dead cross_attention config

## Changed files
- `src/f5_tts/model/backbones/dit_emotion.py` — conditionally create FiLM blocks, remove stale `cross_attention` from InputEmbedding routing, use `.get()` for `load_emotion_weights`
- `src/f5_tts/model/cfm_emotion.py` — remove `drop_emotion_cond = False` override
- `src/f5_tts/model/trainer_emotion.py` — unfreeze FiLM blocks in freeze_backbone path
- `src/f5_tts/train/train_emotion.py` — clean config, fix tokenizer bug, add `film` as active option

## Test plan
- [ ] Verify training launches with `emotion_condition_type='film'` without errors
- [ ] Verify `freeze_backbone=True` correctly freezes transformer but leaves FiLM + emotion_embed trainable
- [ ] Verify dual-CFG (`cfg_strength2`) produces different outputs at inference (confirms emotion dropout is working)
- [ ] Verify other emotion_condition_types (`text_mirror`, `text_early_fusion`, `no_emotion_condition`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)